### PR TITLE
fix: Error handling, refactor output, fix the example helloWorld task

### DIFF
--- a/lib/event-handler.js
+++ b/lib/event-handler.js
@@ -1,7 +1,16 @@
 const eventHandler = resourceLocator => {
   const { logger, task } = resourceLocator
-  const { custom, success, error, info, setSuffix, restoreSuffix } = logger
+  const {
+    warn,
+    custom,
+    success,
+    error,
+    info,
+    setSuffix,
+    restoreSuffix
+  } = logger
   const { runTask } = task
+  const errorList = []
 
   const handleEvent = (event, data) => {
     switch (event) {
@@ -21,13 +30,17 @@ const eventHandler = resourceLocator => {
         setSuffix(data)
         break
       case 'error':
-        error('Taskr has encountered unexpected error, see info below.')
-        error(`${data}\n`)
+        errorList.push(data)
         break
       case 'done':
         custom('')
         restoreSuffix()
-        success('The task has been completed.\n')
+
+        if (!errorList) return success('The task has been completed.\n')
+        error('Taskr has encountered unexpected error/s, see info below.')
+        errorList.forEach(err => error(`${err.message} [ ${err.origin} ]`))
+        warn('The task has been completed with errors.\n')
+
         break
       case 'cmd:missing':
         error('Command is required.')

--- a/lib/task.js
+++ b/lib/task.js
@@ -6,9 +6,10 @@ const event = new eventEmitter()
 const findTask = taskName => {
   if (!taskName) return event.emit('task:missing')
   const cwd = path.resolve('.')
-  const taskrDir = cwd.includes('node_modules')
-    ? `${cwd}/../taskr/tasks/${taskName}.js`
-    : `${cwd}/taskr/tasks/${taskName}.js`
+  const taskrDir =
+    taskName && taskName[0] === 'helloWorld'
+      ? `${__dirname}/../taskr/tasks/${taskName}.js`
+      : `${cwd}/taskr/tasks/${taskName}.js`
   const task = glob.sync(taskrDir)
 
   if (!task.length) return event.emit('task:notFound')
@@ -20,8 +21,8 @@ const runTask = (resourceLocator, { path, name }) => {
   event.emit('task:init', name)
 
   task(resourceLocator, err => {
-    if (err) event.emit('error', err)
-    event.emit('done')
+    if (err) return event.emit('error', err)
+    return event.emit('done')
   })
 }
 


### PR DESCRIPTION
****
- Fix error handling (when error was returned via the task callback, the done callback was being called at the same time, causing the summary message to appear more than once.)
- Refactor the error output.
- The helloWorld task is now working as expected.
****
